### PR TITLE
Enable compatibility with SF4 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make package compatible with Symfony 4
 
 ## [0.2.1] - 2018-06-19
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^5.6|>=7.0.8",
-        "symfony/property-access": "^3.4"
+        "symfony/property-access": "^3.4| ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
# Problem

Optimus use `symfony/property-access` package which is set to `^3.4`. Then usage is limited with SF4

# Solution
Make `symfony/property-access` compatible from `^3.4` to SF4